### PR TITLE
Use the correct stat command for macos and linux

### DIFF
--- a/bin/padto
+++ b/bin/padto
@@ -2,6 +2,10 @@
 
 totalsize=$1
 outfile=$2
-filesize=`stat -f "%z" "$outfile"`
+
+[[ "$OSTYPE" == "linux-gnu" ]] \
+    && filesize=$(stat -c "%s" "$outfile") \
+    || filesize=$(stat -f "%z" "$outfile")
+
 padsize=$((512-$filesize))
 dd if=/dev/zero bs=1 count=$padsize >> "$outfile"


### PR DESCRIPTION
I changed the padto script to run the stat command with the correct arguments for macOS and Linux. I have tested on Linux and macOS Mojave.