### PR TITLE
Fix case on directory name

### DIFF
--- a/src/prelaunch/standard.a
+++ b/src/prelaunch/standard.a
@@ -28,7 +28,7 @@
 +        sta   $1FE
          sty   $1FF
 
-         !source "src/PRELAUNCH/common.a"
+         !source "src/prelaunch/common.a"
 
          ldx   #$FD                  ; Jump to game entry point via stack pop.
          txs


### PR DESCRIPTION
I assume there is a Windows dev box in the mix :). Changed to lowercase to match the directory.