### PR TITLE
Update to winmake + 2 reset fixes

### DIFF
--- a/src/prelaunch/head.on.a
+++ b/src/prelaunch/head.on.a
@@ -1,0 +1,34 @@
+;license:MIT
+;(c) 2019 by qkumba
+
+!cpu 6502
+!to "build/PRELAUNCH/HEAD.ON",plain
+*=$106
+
+    !source "src/prelaunch/common.a"
+
+         lda   #$2C
+         sta   $7000
+         lda   #$88
+         sta   $7001
+         lda   #$C0
+         sta   $7002
+         lda   #$4C
+         sta   $7003
+         lda   #<RELBASE  ; low byte
+         sta   $7004
+         lda   #>RELBASE  ; high byte
+         sta   $7005      ; re-establish LC hook
+
+         lda   #0
+         sta   $3F2
+         lda   #$70
+         sta   $3F3
+         lda   #$D5
+         sta   $3F4       ; reset vector patch
+
+         jmp   $2000
+
+!if * > $1C0 {
+  !error "code is too large, ends at ", *
+}

--- a/src/prelaunch/quadrant.6112.a
+++ b/src/prelaunch/quadrant.6112.a
@@ -1,0 +1,39 @@
+;license:MIT
+;(c) 2019 by qkumba
+
+!cpu 6502
+!to "build/PRELAUNCH/QUADRANT.6112",plain
+*=$106
+
+    !source "src/prelaunch/common.a"
+
+         lda   #$60       ; RTS instead of JMP
+         sta   $872
+         jsr   $800       ; title
+
+         lda   #$2C
+         sta   $100
+         lda   #$88
+         sta   $101
+         lda   #$C0
+         sta   $102
+         lda   #$4C
+         sta   $103
+         lda   #<RELBASE  ; low byte
+         sta   $104
+         lda   #>RELBASE  ; high byte
+         sta   $105       ; re-establish LC hook
+
+         lda   #0
+         sta   $3f2
+         lda   #1
+         sta   $3f3
+         lda   #$A4
+         sta   $3f4       ; reset vector patch
+
+         jmp   $2007
+
+
+!if * > $1C0 {
+  !error "code is too large, ends at ", *
+}

--- a/winmake.bat
+++ b/winmake.bat
@@ -144,6 +144,6 @@ goto :EOF
 for %%q in (src\prelaunch\*.a) do (
   for /f "tokens=* usebackq" %%k in (`find "^!to" %%q`) do set _to=%%k
   set _to=!_to:~0,1!
-  if !_to!==t %ACME% %%q
+  if !_to!==t %ACME% -DRELBASE=$!_make:~-5,4! %%q
 for %%q in (res\title.hgr\*) do if not exist build\prelaunch\%%~nxq 1>nul copy build\prelaunch\standard build\prelaunch\%%~nxq
 )


### PR DESCRIPTION
asmprelaunch needed an update to have relbase available. 2 new fixes use relbase.