### PR TITLE
softswitch fix

### DIFF
--- a/src/prelaunch/vindicator.a
+++ b/src/prelaunch/vindicator.a
@@ -18,6 +18,10 @@
          lda   #$BF
          sta   $400F      ; reset vector fix
 
+         lda   #$60       ; annunciator fix - kills Gizmo/joyport support
+         sta   $5B77      ; but fixes ][+ 80-col softswitch
+         sta   $5B43      ; and //c+ coloring
+
          +DISABLE_ACCEL
          jmp   $4000
 


### PR DESCRIPTION
'gizmo' setting hits annunciator switches that turn off graphics on ][+ 80-column softswitch. joyport setting hits //c+ coloring switch.