### PR TITLE
Fix video transition code in @start

### DIFF
--- a/src/4cade.init.a
+++ b/src/4cade.init.a
@@ -408,6 +408,12 @@ CopyDevs
          bcc   @outer
 
          bit   CLEARKBD
+
+         +READ_ROM_NO_WRITE
+         jsr   ROM_TEXT              ; let's reset the window boundaries
+         jsr   ROM_HOME              ; and clear text screen 1
+         +READ_RAM1_WRITE_RAM1
+
          jmp   Reenter
 
 @kGameListConfFile

--- a/src/ui.common.a
+++ b/src/ui.common.a
@@ -66,12 +66,22 @@ Home
          jmp   $106
 @start
          ; this will be run from main memory
-         +READ_ROM_NO_WRITE
+         lda   #$A0                  ; clear text screen page 1
+         ldx   #$77
+-        sta   $400,x
+         sta   $480,x
+         sta   $500,x
+         sta   $580,x
+         sta   $600,x
+         sta   $680,x
+         sta   $700,x
+         sta   $780,x
+         dex
+         bpl   -
+
          sta   DHIRESOFF             ; get out of DHGR mode
          sta   CLR80VID              ; get out of DHGR mode
                                      ; write-order matters for RGB-card
-         jsr   $FB3C ;ROM_TEXTish    ; clear screen but don't show it
-         jsr   ROM_HOME              ; HOME
          lda   PAGE1
          lda   $C051                 ; now show it
 SwitchToBank1


### PR DESCRIPTION
reduces the glitchiness on video mode changes introduced by TEXT.

I left in "SwitchToBank1" because it's called externally, even though we are still on LC bank 1 now.