### PR TITLE
fix Mating Zone title screen

### DIFF
--- a/src/prelaunch/mating.zone.a
+++ b/src/prelaunch/mating.zone.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2020 by qkumba
+;(c) 2020 by qkumba/Frank M.
 
 !cpu 6502
 !to "build/PRELAUNCH/MATING.ZONE",plain
@@ -7,7 +7,7 @@
 
     !source "src/prelaunch/common.a"
 
-         +ENABLE_ACCEL
+         ;+ENABLE_ACCEL   ; acceleration breaks title on //gs, Fastchip, and Mac //e Card
          lda   #$60
          sta   $6B18
          jsr   $495E      ; decompress
@@ -17,7 +17,7 @@
          lda   #$a5
          sta   $729F      ; patch - don't decrease lives
 +
-         +DISABLE_ACCEL
+         ;+DISABLE_ACCEL
          jmp   $BF8
 
 !if * > $1C0 {


### PR DESCRIPTION
Most machines with acceleration show the title screen flipping between pages way too fast. Affects (and fixes) //gs, Fastchip, and Mac //e Card.