### PR TITLE
fixes for games on //c+

### DIFF
--- a/src/prelaunch/arctic.fox.a
+++ b/src/prelaunch/arctic.fox.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2020 by qkumba
+;(c) 2020 by qkumba/Frank M.
 
 !cpu 6502
 !to "build/PRELAUNCH/ARCTIC.FOX",plain
@@ -7,8 +7,11 @@
 
     !source "src/prelaunch/common.a"
 
+         lda   $FBBF
+         cmp   #5         ; disable acceleration on //c+
+         beq   +          ; because of coloring issues
          +ENABLE_ACCEL
-         lda   #>(callback-1)
++        lda   #>(callback-1)
          sta   $4280
          lda   #<(callback-1)
          sta   $4283
@@ -17,9 +20,12 @@
 callback
          +LC_REBOOT
          inc   $3F4       ; force reboot
+         lda   $FBBF
+         cmp   #5
+         beq   +
          bit   $C083
          jsr   DisableAccelerator
-         +READ_RAM1_WRITE_RAM1
++        +READ_RAM1_WRITE_RAM1
          jmp   $1170
 
 !if * > $1C0 {

--- a/src/prelaunch/arkanoid.a
+++ b/src/prelaunch/arkanoid.a
@@ -7,8 +7,11 @@
 
     !source "src/prelaunch/common.a"
 
+         lda   $FBBF
+         cmp   #5         ; disable acceleration on //c+
+         beq   +          ; because of coloring issues
          +ENABLE_ACCEL
-         lda   #$60
++        lda   #$60
          sta   $97e
          jsr   $800
 
@@ -19,9 +22,14 @@
          sta   $145c
          sta   $1d65
 +
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          lda   $c083
          jsr   DisableAccelerator
-         lda   $c08b
++        lda   $c08b
          jsr   $ee1f
 
          +LC_REBOOT

--- a/src/prelaunch/battle.chess.a
+++ b/src/prelaunch/battle.chess.a
@@ -7,8 +7,11 @@
 
     !source "src/prelaunch/common.a"
 
+         lda   $FBBF
+         cmp   #5         ; disable acceleration on //c+
+         beq   +          ; because of coloring issues
          +ENABLE_ACCEL
-         inc   $3F4       ; force reboot
++        inc   $3F4       ; force reboot
          lda   #$50
          sta   $933
          lda   #2
@@ -22,9 +25,14 @@
 
 callback !pseudopc $250 {
          sta   $C008
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          bit   $C083
          jsr   DisableAccelerator
-         bit   $C08B
++        bit   $C08B
          sta   $C009
          jmp   $C00
 }

--- a/src/prelaunch/black.magic.a
+++ b/src/prelaunch/black.magic.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2019 by qkumba
+;(c) 2019 by qkumba/Frank M.
 
 !cpu 6502
 !to "build/PRELAUNCH/BLACK.MAGIC",plain
@@ -7,28 +7,55 @@
 
     !source "src/prelaunch/common.a"
 
+         lda   $FBBF
+         cmp   #5         ; disable acceleration on //c+
+         beq   +          ; because of coloring issues
          +ENABLE_ACCEL
-         lda   #$60
++        lda   #$60
          sta   $9C2
          jsr   $800       ; decompress
 
          lda   #$60
          sta   $1B2D
          sta   $D6E6
+
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          jsr   DisableAccelerator
-         jsr   $1B00
++        jsr   $1B00
+
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          jsr   EnableAccelerator
-         jsr   $D000
++        jsr   $D000
+
          lda   #<callback
          sta   $8D5
          lda   #>callback
          sta   $8D6
+
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          jsr   DisableAccelerator
-         jmp   $800
++        jmp   $800
 
 callback
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          jsr   EnableAccelerator
-         jsr   $D003
++        jsr   $D003
          ldx   #5
 -        lda   reset, x
          sta   $4182, x
@@ -36,7 +63,14 @@ callback
          bpl   -
          lda   #$20
          sta   $D6EB
+
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          jmp   DisableAccelerator
++        rts
 
 reset
          +READ_ROM_NO_WRITE

--- a/src/prelaunch/mating.zone.a
+++ b/src/prelaunch/mating.zone.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2020 by qkumba
+;(c) 2020 by qkumba/Frank M.
 
 !cpu 6502
 !to "build/PRELAUNCH/MATING.ZONE",plain
@@ -10,14 +10,18 @@
          +ENABLE_ACCEL
          lda   #$60
          sta   $6B18
+         sta   $49D4
          jsr   $495E      ; decompress
+         jsr   $BD41
+         +DISABLE_ACCEL
+         jsr   $B59B
+
          +GET_MACHINE_STATUS
          and   #CHEATS_ENABLED
          beq   +
          lda   #$a5
          sta   $729F      ; patch - don't decrease lives
 +
-         +DISABLE_ACCEL
          jmp   $BF8
 
 !if * > $1C0 {

--- a/src/prelaunch/realm.imposs.a
+++ b/src/prelaunch/realm.imposs.a
@@ -7,8 +7,11 @@
 
     !source "src/prelaunch/common.a"
 
+         lda   $FBBF
+         cmp   #5         ; disable acceleration on //c+
+         beq   +          ; because of coloring issues
          +ENABLE_ACCEL
-         +READ_RAM1_WRITE_RAM1
++        +READ_RAM1_WRITE_RAM1
          +LC_REBOOT
          +READ_ROM_NO_WRITE
 
@@ -22,10 +25,15 @@
          lda   #$2C
          sta   $AF1D      ; patch - don't decrease hit-points
 +
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          +READ_RAM2_WRITE_RAM2
          jsr   DisableAccelerator
-         +READ_RAM1_WRITE_RAM1
-         jmp   $1953
+        +READ_RAM1_WRITE_RAM1
++        jmp   $1953
 
 !if * > $1C0 {
   !error "code is too large, ends at ", *

--- a/src/prelaunch/spindizzy.a
+++ b/src/prelaunch/spindizzy.a
@@ -7,9 +7,12 @@
 
     !source "src/prelaunch/common.a"
 
+         lda   $FBBF
+         cmp   #5         ; disable acceleration on //c+
+         beq   +          ; because of coloring issues
          +ENABLE_ACCEL
 
-         +READ_RAM1_WRITE_RAM1
++        +READ_RAM1_WRITE_RAM1
          +LC_REBOOT
          +READ_ROM_NO_WRITE
 
@@ -22,8 +25,13 @@
          inx
          stx   $934F      ; fix reboot
 
+         +READ_ROM_NO_WRITE
+         lda   $FBBF
+         +READ_RAM1_WRITE_RAM1
+         cmp   #5
+         beq   +
          +DISABLE_ACCEL
-         jmp   $9300
++        jmp   $9300
 
 !if * > $1C0 {
   !error "code is too large, ends at ", *


### PR DESCRIPTION
skips acceleration if //c+ detected. fixes various color mode and double-hires problems.
arctic.fox.a
arkanoid.a
battle.chess.a
black.magic.a
realm.imposs.a
spindizzy.a