### PR TITLE
IIc HGR colour fix, and DHGR works.

### DIFF
--- a/src/hw.accel.a
+++ b/src/hw.accel.a
@@ -383,8 +383,10 @@ FASTChip
          lda   #FC_LOCK
          sta   fc_lock
 
+         lda   gMachineInDHGRMode  ; Fix for iic colours, but only in HGR.
+         bne   +
 fixiic
          bit   $C05D     ; fix colouring on IIc (SMC to STA on IIc)
-         plp             ; restore interrupt state
++        plp             ; restore interrupt state
          rts
 end_addon


### PR DESCRIPTION
Here is my attempt at a fix. I stole your code to put a check on your fix to only apply it in HGR mode, since it seems to clobber DHGR.

Tested on AppleWin (2e) and my 2c with Rom4X. Somehow I didn't break it!