### PR TITLE
fix Black Magic on //c+

### DIFF
--- a/src/prelaunch/black.magic.a
+++ b/src/prelaunch/black.magic.a
@@ -22,13 +22,11 @@
          sta   $1B2D
          sta   $D6E6
          jsr   $1B00
-
          lda   #<callback1
          sta   $D7E9
          lda   #>callback1
          sta   $D7EA
          jsr   $D000
-
          lda   #<callback2
          sta   $8D5
          lda   #>callback2
@@ -55,6 +53,7 @@ callback2
          lda   #$63       ; back to original vector
          sta   $3F2
          sta   $FFFC
+         +READ_RAM2_WRITE_RAM2      ; fix on //c+
          jmp   $D6EE
 
 reset


### PR DESCRIPTION
Seems like starting a new game is wonky. after it shows the high score screen it messes up the graphics. not sure if that's my fix causing it or not, but both reset work, and every machine (tm) works currently.