### PR TITLE
fix Fastchip joystick detection

### DIFF
--- a/src/4cade.init.a
+++ b/src/4cade.init.a
@@ -31,6 +31,35 @@
 @no64Klen=(*-@s_no64K)-1
 
 +
+; FASTChip
+fc_lock         =    $C06A
+fc_enable       =    $C06B
+fc_config       =    $C06E
+fc_data         =    $C06F
+FC_UNLOCK       =    $6A     ; write 4 times
+FC_LOCK         =    $A6
+FC_SPKR         =    2       ; speaker delay register
+FC_HIFI         =    4       ; set to 'HIFI'
+FC_JOY          =    3       ; joystick delay register
+FC_LONG         =    2       ; set to 'LONG'
+
+         lda   #FC_UNLOCK
+         sta   fc_lock
+         sta   fc_lock
+         sta   fc_lock
+         sta   fc_lock
+         sta   fc_enable
+         lda   #FC_SPKR              ; change Fastchip speaker delay setting to 'HIFI'
+         sta   fc_config             ; (improves sound on most games)
+         lda   #FC_HIFI
+         sta   fc_data
+         lda   #FC_JOY               ; change Fastchip joystick delay setting to 'LONG'
+         sta   fc_config             ; (improves joystick detection)
+         lda   #FC_LONG
+         sta   fc_data
+         lda   #FC_LOCK              ; (settings revert on power cycle)
+         sta   fc_lock
+
          lda   #0
          sta   zpMachineStatus
          sta   SETC3ROM

--- a/src/hw.accel.a
+++ b/src/hw.accel.a
@@ -125,8 +125,6 @@ FC_UNLOCK       =    $6A     ; write 4 times
 FC_LOCK         =    $A6
 FC_1MHZ         =    9
 FC_ON           =    40      ; doco says 16.6Mhz
-FC_SPKR         =    2
-FC_HIFI         =    4
 
 ; TransWarp I
 ; may overlap with paddle trigger
@@ -214,19 +212,6 @@ build_setspeed
          rts
 
 build_addon
-         lda   #FC_UNLOCK            ; change Fastchip speaker setting to 'HIFI'
-         sta   fc_lock               ; (improves sound on most games)
-         sta   fc_lock               ; (setting reverts on power cycle)
-         sta   fc_lock
-         sta   fc_lock
-         sta   fc_enable
-         lda   #FC_SPKR
-         sta   fc_config
-         lda   #FC_HIFI
-         sta   fc_data
-         lda   #FC_LOCK
-         sta   fc_lock
-
          lda   #<addon
          ldy   #>addon
          ldx   #(end_addon-addon)


### PR DESCRIPTION
version 0.4b of the Fastchip firmware needs the joystick setting to be set to 'LONG' for the TR joystick detection to work. This patch changes the setting before joystick detection happens. Should fix #335.