### PR TITLE
Don't change the Z-RAM Date

### DIFF
--- a/src/hw.accel.a
+++ b/src/hw.accel.a
@@ -196,7 +196,7 @@ iic
          sta   fixiic+2
          ldx   romid_c
          cpx   #ROMID_CPLUS
-         bne   build_addon ; not a //c+, eventually hit Zip
+         bne   build_addon_iic ; not a //c+, eventually hit Zip
 
          lda   #<iicplus
          ldy   #>iicplus
@@ -217,6 +217,11 @@ build_addon
          ldx   #(end_addon-addon)
          rts
 
+build_addon_iic
+         lda   #<addon_iic
+         ldy   #>addon_iic
+         ldx   #(end_addon-addon_iic)
+         rts
 ;-----------------------------------------------------------
 ; 3 distinct accelerator functions
 ;
@@ -341,6 +346,29 @@ addon
          ; no UW support here because the softswitch to enable
          ; acceleration triggers DHGR bugs in OpenEmulator :-(
 
+         ldy   #FC_1MHZ
+         tax
+         eor   #1
+         beq   FASTChip
+         ldy   #FC_ON
+FASTChip
+         lda   #FC_UNLOCK
+         sta   fc_lock
+         sta   fc_lock
+         sta   fc_lock
+         sta   fc_lock
+         sta   fc_enable
+         sty   fc_speed
+         lda   #FC_LOCK
+         sta   fc_lock
+         
+         txa
+         !byte   $2C      ; BIT <ABSOLUTE>, hide next lda #
+addon_iic         
+         lda     #1       ; disable accelerator entry point
+         !byte   $2C      ; BIT <ABSOLUTE>, hide next lda #
+         lda     #0       ; enable accelerator entry point
+
          ; Zip Chip
          ldy   #FC_1MHZ
          eor   #1
@@ -359,20 +387,9 @@ addon
          lda   #ZC_LOCK
          sta   zc_lock
 
-FASTChip
-         lda   #FC_UNLOCK
-         sta   fc_lock
-         sta   fc_lock
-         sta   fc_lock
-         sta   fc_lock
-         sta   fc_enable
-         sty   fc_speed
-         lda   #FC_LOCK
-         sta   fc_lock
-
          ldx   gMachineInDHGRMode
 fixiic
          bit   $D05F     ; fix colouring on IIc (SMC to STA,X on IIc)
-+        plp             ; restore interrupt state
+         plp             ; restore interrupt state
          rts
 end_addon


### PR DESCRIPTION
a2-4am/4cade#346 Currently the FASTChip is not available for the //c and its addresses are the same as in the Z-RAM Ultra 2/3 Clock. The FASTChip activation/deactivation modifies the date and sets it to invalid values that prevent ProDOS 2.4.2 from booting.
To avoid this, if a //c is detected a shorter addon routine only with ZipChip support is used.