### PR TITLE
fix Run For It unpause

### DIFF
--- a/src/prelaunch/run.for.it.a
+++ b/src/prelaunch/run.for.it.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2020 by qkumba
+;(c) 2020-2021 by qkumba/xot
 
 !cpu 6502
 !to "build/PRELAUNCH/RUN.FOR.IT",plain
@@ -21,6 +21,9 @@
          sta   $906
          sta   $1286
 +
+         lda   #$fb       ; fix unpause
+         sta   $e29
+
          lda   #<callback
          sta   $15C8
          lda   #>callback


### PR DESCRIPTION
This corrects a key-wait antipattern I originally observed in Mr. Xerox's Dung Beetles crack. For some reason, I thought it would be fun to search for it in other games. It popped up in the pause routine of _Run For It_.

Here is the problematic code:
```
0e22- 8d 10 c0      sta     $C010    ; reset keyboard strobe <------------.
0e25- ad 00 c0      lda     $c000    ; read keyboard                      |
0e28- 10 f8         bpl     $0e22    ; repeat until keyboard strobe set --'
```
Once the game is paused, this is supposed to loop until a key is pressed to unpause it. The problem is it is constantly clearing the keyboard strobe. This makes detecting key presses unreliable and they are often missed. The prelauncher patches 1-byte to make the loop branch to the keyboard read instead of the strobe reset. The byte changes from `F8` to `FB`. Their resemblance makes me wonder if it was a typo.