### PR TITLE
fix broken Moon Patrol prelauncher

### DIFF
--- a/src/prelaunch/moon.patrol.a
+++ b/src/prelaunch/moon.patrol.a
@@ -9,11 +9,9 @@
 
          +ENABLE_ACCEL
          lda   #$60
-         sta   $49d5
+         sta   $49dd
          jsr   $800
-         lda   #$60
-         sta   $2fe
-         jsr   $2ef
+
          +GET_MACHINE_STATUS
          and   #CHEATS_ENABLED
          beq   +


### PR DESCRIPTION
dsk image was change a couple months ago and it looks like MP hasn't worked since. Not sure if the cheats still work or not.