### PR TITLE
force IIgs Mono Mode off

### DIFF
--- a/src/4cade.init.a
+++ b/src/4cade.init.a
@@ -100,6 +100,13 @@
          inx
          bne   -
 !cpu 6502
+
+         ; Since we know we are on IIgs, let's also force Mono Mode off
+         lda   NEWVIDEO
+         and   #$DF
+         sta   NEWVIDEO              ; Bit 5=1 for B/W double hi-res
+         lda   #$00
+         sta   MONOCOLOR             ; bit 7=1 disables color
 +
 
          ; increase text window width so we can print to the edge of the screen without scrolling

--- a/src/constants.a
+++ b/src/constants.a
@@ -88,6 +88,7 @@ CLR80VID =     $C00C      ; 40 columns (also used to get out of DHGR mode)
 SET80VID =     $C00D      ; 80 columns (also used to get into DHGR mode)
 PRIMARYCHARSET= $C00E     ; no mousetext for you
 SLOT3STATUS =  $C017      ; bit 7 only
+MONOCOLOR =    $C021      ; IIgs bit 7 switches composite mono/color modes
 TBCOLOR =      $C022      ; IIgs text foreground and background colors (also VidHD but write-only)
 NEWVIDEO =     $C029      ; IIgs graphics modes (also VidHD)
 SPEAKER =      $C030      ; chirp chirp


### PR DESCRIPTION
A (since fixed) bug in Apple II Desktop led to a black and white main screen on TR. Let's force color mode on in case it's off.