### PR TITLE
fix Victory Road graphics glitch

### DIFF
--- a/src/prelaunch/victory.road.a
+++ b/src/prelaunch/victory.road.a
@@ -24,6 +24,10 @@ callback
          jsr   $300
          +ENABLE_ACCEL
          inc   $3F4       ; force reboot on reset during title screen
+         lda   #$D0
+         sta   $119C
+         sta   $119F
+         sta   $11A2      ; reduce visual glitch on graphics mode change
          lda   #$60
          sta   $11A7
          jsr   $1000      ; decompress


### PR DESCRIPTION
Victory Road has two sections which turn on the graphics. The first happens directly before a decompress routine, and does not turn on double-res mode. The later routine sets all switches, so we skip the first by just reading from $D0xx instead.