### PR TITLE
fix hang on Pollywog demo on ROM0/1 Apple IIgs

### DIFF
--- a/src/demo/pollywog.a
+++ b/src/demo/pollywog.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2024 by qkumba
+;(c) 2024 by qkumba/Frank M.
 
 !cpu 6502
 !to "build/DEMO/POLLYWOG#060300",plain
@@ -9,12 +9,12 @@
          !source "src/macros.a"
 
          +GAME_REQUIRES_JOYSTICK
-
+         +TEST_TEXT_PAGE_2           ; will look wonky on ROM0/1 Apple //gs
+                                     ; due to lores page flipping
          +ENABLE_ACCEL_LC
          +LOAD_XSINGLE title
+         +READ_ROM_NO_WRITE
 
-         +USES_TEXT_PAGE_2
-         +ENABLE_ACCEL
          lda   #$60
          sta   $82C
          jsr   $800       ; decompress


### PR DESCRIPTION
All other demos use +TEST_TEXT_PAGE_2. The makes the into lores intro animation 'flash' on ROM0/1 IIgs, but fixes hanging due to VBL interrupts when the demo is finished. ROM3 looks fine, and did not hang, as it doesn't use VBL interrupts for Alternate Display Mode.