### PR TITLE
clear HGR to BLACK2

### DIFF
--- a/src/ui.offscreen.a
+++ b/src/ui.offscreen.a
@@ -237,7 +237,7 @@ CopyHGR
 +        sty   PageFrom
          sta   PageTo+2
 ClearToBlack
-         lda   #$00
+         lda   #$80                  ; clear to BLACK2
 ClearGR
          ldy   #0
 PageFrom lda   $FD00,y               ; SMC address high byte, also SMC opcode (might be BIT)


### PR DESCRIPTION
I've noticed some unfortunate artifacts appearing on help pages. The screen is cleared to black and then text is drawn to it. The text has the high-bit set (orange/blue) but the background does not (green/purple). This transition from palette 2 to palette 1 will cause the rightmost pixel in a byte to get cut in half.

Note here "n", "h", "d", "e", "M" at the end of lines appear shortened and pink on their right sides.
![Mono6502_2024-10-19_02-34-59](https://github.com/user-attachments/assets/437e2136-cc2a-49d0-8c8d-252d8a1ec326)

Here is what it looks like when the background has its high-bit set. Those letters appear fully formed.
![Mono6502_2024-10-19_02-45-42](https://github.com/user-attachments/assets/53716fba-b92a-490c-be09-61f4a7c477c1)

It's subtle but once you see it you can't unsee it.

I created this patch to achieve the desired result, but since I am unfamiliar with the bulk of the code, I don't know if this change might have side effects elsewhere.