### PR TITLE
Allow TR to control Alternate Display Mode shadowing

### DIFF
--- a/src/glue.launch.lc2.a
+++ b/src/glue.launch.lc2.a
@@ -60,7 +60,7 @@ LaunchInternal
          sta   HideLaunchArtworkLC2
          bne   @jmp                  ; always branches
 @turnOffSHRShadow
-         lda   #%00101000            ; matches powerup value
+         lda   #%00001000            ; we want to control ADM, so we do not want to match the powerup value
          sta   SHADOW
          sta   SHADOW
 @jmp     jmp   iPrelaunchInit


### PR DESCRIPTION
A recent commit broke the ability to control shadowing/Alternate Display Mode. On powerup, the bit is set to disable page 2 shadowing. We actually want to control that, so we need to keep the bit set to zero. Some sources show this but as "unused" but according to the IIgs Hardware Reference: Bit 5 - Text Page 2 inhibit (available only on the 1 MB logic board): When this bit is 1, shadowing is disabled for text Page 2 and auxiliary text Page 2.