### PR TITLE
add new self-running demo for Paipec

### DIFF
--- a/src/demo/paipec.a
+++ b/src/demo/paipec.a
@@ -1,0 +1,46 @@
+;license:MIT
+;(c) 2026 by Frank M.
+
+!cpu 6502
+!to "build/DEMO/PAIPEC#060300",plain
+*=$300
+
+         !source "src/constants.a"   ; no code in these
+         !source "src/macros.a"
+
+         +GAME_REQUIRES_JOYSTICK
+
+         +ENABLE_ACCEL_LC
+         +LOAD_XSINGLE title
+
+         lda   #$60
+         sta   $4031
+         jsr   $4000      ; decompress
+
+         lda   #$D0
+         sta   $E96       ; suppress sound
+
+         stx   $692A      ; x=0
+         inx
+         stx   $692B      ; exit on keypress
+
+         lda   #<callback
+         sta   $66D1+1
+         lda   #>callback
+         sta   $66D1+2    ; set exit at end of demo cycle
+
+         +DISABLE_ACCEL
+         jmp   $1AD0
+
+callback dec   count
+         bne   +
+         jmp   $100       ; exit after 5 levels (about 1 minute)
++        jmp   $6971      ; run one loop
+
+count    !byte 6
+
+title    +PSTRING "PAIPEC"
+
+!if * > $3F0 {
+  !error "code is too large, ends at ", *
+}


### PR DESCRIPTION
Paipec Demo Notes:


0E94: AD 30 C0  LDA $C030  Speaker



6924: 2E 00 C0  ROL $C000
6927: 90 03     BCC $692C
6929: 4C 40 69  JMP $6940  -->$100   692A:00 01
692C: no keypress




Loop
66D1: 20 71 69  JSR $6971  run loop once



Single load - requires joystick