### PR TITLE
fix game help for Bandits

### DIFF
--- a/res/GAMEHELP/BANDITS
+++ b/res/GAMEHELP/BANDITS
@@ -3,7 +3,7 @@
 
                keyboard
 
-  A stop  S shield     move  < >  move
+  A stop  S shields    move  < >  move
 
 Space* * * * * * * * * * * * * * * *fire
 
@@ -12,7 +12,7 @@ Ctrl-P * * * * * * * * * * * * * *paddle
 
            button 0 to fire
 
-Space* * * * * * * * * * * * * * *shield
+           button 1 shields
 
 
 Esc* * * * * * * * * * * * * * * * pause


### PR DESCRIPTION
The game help for Bandits has an error. This version of Bandits has been modified to use `BUTN1` instead of `SPACE` to activate shields. This patch fixes the game help to reflect this change (compare below). I have also changed "shield" to "shields" for alignment and consistency. Both spellings are used in the original manual. 

Updated Game Help
<img width="1400" height="960" alt="Mono6502_2026-06-12_13-51-29" src="https://github.com/user-attachments/assets/a1468ba2-4220-49c2-bbdb-d04255908132" />

Old Game Help
<img width="1400" height="960" alt="Mono6502_2026-06-12_13-42-24" src="https://github.com/user-attachments/assets/7a4dd329-4223-4e4d-8232-4af639a8316e" />


