### PR TITLE
Allow demos using text page 2 to launch on ][+

### DIFF
--- a/src/demo/pollywog.a
+++ b/src/demo/pollywog.a
@@ -9,10 +9,7 @@
          !source "src/macros.a"
 
          +GAME_REQUIRES_JOYSTICK
-         
-         lda   ROM_MACHINEID         ; is already on. ROM0 and ROM1 versions of ADM use
-         cmp   #$06                  ; interrupts and can cause hangs, so safer to just
-         bne   ++                    ; leave it turned off, especially in ATTRACT/DEMO mode.
+
          sec
          jsr   $FE1F                 ; check for IIgs
          bcs   +++

--- a/src/macros.a
+++ b/src/macros.a
@@ -427,10 +427,8 @@
 
 ; ROM must be banked in!
 !macro   USES_TEXT_PAGE_2 {          ; If we know we are going into a game one-time
-         lda   ROM_MACHINEID         ; only we can just blindly turn on TEXT2COPY, as
-         cmp   #$06                  ; Alternate Display Mode turns off on reset or reboot.
-         bne   +
-         sec
+                                     ; only we can just blindly turn on TEXT2COPY, as
+         sec                         ; Alternate Display Mode turns off on reset or reboot.
          jsr   $FE1F                 ; check for IIgs
          bcs   +
          jsr   ROM_TEXT2COPY         ; set alternate display mode on IIgs (required for some games)
@@ -440,10 +438,9 @@
 
 ; ROM must be banked in!
 !macro   TEST_TEXT_PAGE_2 {          ; On a ROM3 IIgs we can test if Alternate Display Mode
-         lda   ROM_MACHINEID         ; is already on. ROM0 and ROM1 versions of ADM use
-         cmp   #$06                  ; interrupts and can cause hangs, so safer to just
-         bne   ++                    ; leave it turned off, especially in ATTRACT/DEMO mode.
-         sec
+                                     ; is already on. ROM0 and ROM1 versions of ADM use
+                                     ; interrupts and can cause hangs, so safer to just
+         sec                         ; leave it turned off, especially in ATTRACT/DEMO mode.
          jsr   $FE1F                 ; check for IIgs
          bcs   ++
          tya                         ; GS ID routine returns with ROM version in Y


### PR DESCRIPTION
We don't need to test ROM_MACHINEID since $FE1F is always either RTS or the //gs ID routine.