### PR TITLE
limits Vindicator controller selection

### DIFF
--- a/src/prelaunch/vindicator.a
+++ b/src/prelaunch/vindicator.a
@@ -1,5 +1,5 @@
 ;license:MIT
-;(c) 2019-2020, 2026 by Frank M./qkumba
+;(c) 2019-2020, 2026 by Frank M./qkumba/xot
 
 !cpu 6502
 !to "build/PRELAUNCH.INDEXED/VINDICATOR",plain
@@ -31,6 +31,13 @@ callback
          sty   $400F      ; reset vector fix
          dey
          sty   $4001
+
+         lda   #$A9       ; limits controller selection to
+         sta   $55DB      ; keyboard (02) and joystick (FF)
+         lda   #$FD       ;
+         sta   $55DC      ; 55DB: lda #$FD
+         lda   #$45       ;       eor $27
+         sta   $55DD      ;       ...
 
          lda   #$60       ; annunciator fix - kills Gizmo/joyport support
          sta   $5B77      ; but fixes ][+ 80-col softswitch


### PR DESCRIPTION
I was testing my emulator's Joyport implementation and was very confused by the crazy Joyport movement in Total Replay's Vindicator. After some sleuthing, I saw that the prelauncher disabled the Joyport and Gizmo read code.

This 3-byte patch prevents Joyport and Gizmo controls from being selected in the first place.

```
55DB: INC $27    --> LDA #$FD
55DD: LDA $27    --> EOR $27
55DF: CMP #$03
55E1: BCC $55E5
55E3: LDA #$FF
55E5: STA $27
```

The original code cycles controllers through $FF (joystick), $00 (Gizmo), $01 (Joyport), and $02 (keyboard). The patch switches between $FF (joystick) and $02 (keyboard) only.